### PR TITLE
Add code highlight and use Darksky namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ A simple wrapper for Dark Sky API
 - Get the API key from https://darksky.net/dev
 - Install this package in your project:<br> `composer require darksky/darksky`
 - To forecast:
-```
+```php
+use Darksky\Darksky;
+
 try {
     $result = (new Darksky('API_KEY'))->forecast('LAT', 'LONG');
 } catch(DarkskyException $e) {
@@ -33,7 +35,9 @@ try {
 ```
 
 - To use the time machine:
-```
+```php
+use Darksky\Darksky;
+
 try {
     $result = (new Darksky('API_KEY'))->timeMachine('LAT', 'LONG', 'UNIX_TIME');
 } catch(DarkskyException $e) {


### PR DESCRIPTION
# Changed log
- Add `php` for making code highlight.
- Add `use Darksky\Darksky;` to let sample codes correctly and make developers easy to understand.